### PR TITLE
Fix runtime type mismatch for cargo test

### DIFF
--- a/helix-container/src/main.rs
+++ b/helix-container/src/main.rs
@@ -81,8 +81,8 @@ async fn main() {
     ).await;
     // start server
     println!("Starting server...");
-    let a = gateway.connection_handler.accept_conns().await.unwrap();
-    let b = a.await.unwrap();
+    let handle = gateway.connection_handler.accept_conns().await.unwrap();
+    handle.await;
 
 }
 

--- a/helixdb/src/helix_runtime/mod.rs
+++ b/helixdb/src/helix_runtime/mod.rs
@@ -8,7 +8,9 @@ use std::pin::Pin;
 /// Production code uses a Tokio-backed implementation while tests can
 /// provide deterministic schedulers by implementing this trait.
 pub trait AsyncRuntime {
-    type JoinHandle<T>: Future<Output = T> + Send + 'static;
+    type JoinHandle<T>: Future<Output = T> + Send + 'static
+    where
+        T: Send + 'static;
 
     /// Spawn a future onto the runtime.
     fn spawn<F, T>(&self, fut: F) -> Self::JoinHandle<T>

--- a/helixdb/src/helix_runtime/tokio_runtime.rs
+++ b/helixdb/src/helix_runtime/tokio_runtime.rs
@@ -1,21 +1,47 @@
 use super::AsyncRuntime;
 use std::future::Future;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 /// Tokio based implementation of [`AsyncRuntime`].
 #[derive(Clone, Default)]
 pub struct TokioRuntime;
 
+/// Wrapper around [`tokio::task::JoinHandle`] that yields the task result
+/// directly and panics if the task failed.
+pub struct TokioJoinHandle<T>(tokio::task::JoinHandle<T>);
+
+// SAFETY: `TokioJoinHandle` is only constructed via `TokioRuntime::spawn`,
+// which requires `T: Send + 'static`. Therefore it is safe to mark this type
+// as `Send` for all `T`.
+unsafe impl<T> Send for TokioJoinHandle<T> {}
+
+impl<T> Future for TokioJoinHandle<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Safety: just projecting the inner JoinHandle
+        let inner = unsafe { self.map_unchecked_mut(|s| &mut s.0) };
+        match inner.poll(cx) {
+            Poll::Ready(Ok(val)) => Poll::Ready(val),
+            Poll::Ready(Err(err)) => panic!("Tokio task failed: {}", err),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
 impl AsyncRuntime for TokioRuntime {
-    type JoinHandle<T> = tokio::task::JoinHandle<T>;
+    type JoinHandle<T> = TokioJoinHandle<T>
+    where
+        T: Send + 'static;
 
     fn spawn<F, T>(&self, fut: F) -> Self::JoinHandle<T>
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        tokio::spawn(fut)
+        TokioJoinHandle(tokio::spawn(fut))
     }
 
     fn sleep(&self, dur: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {


### PR DESCRIPTION
## Summary
- update async runtime to wrap tokio JoinHandle
- constrain associated JoinHandle type for Send + 'static
- adjust container example to await handle directly

## Testing
- `cargo t` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684325fd25ec832db32034e2873b54b8