### PR TITLE
Silence unused variable warnings

### DIFF
--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -1020,12 +1020,11 @@ fn main() {
                 Err(e) => println!("{} {}", "Error while stopping instance".red().bold(), e),
             }
 
-            let mut del_prompt: bool = false;
             print!("Are you sure you want to delete the instance and its data? (y/n): ");
             std::io::stdout().flush().unwrap();
             let mut input = String::new();
             std::io::stdin().read_line(&mut input).unwrap();
-            del_prompt = input.trim().to_lowercase() == "y";
+            let del_prompt = input.trim().to_lowercase() == "y";
 
             if del_prompt {
                 match instance_manager.delete_instance(iid) {
@@ -1176,7 +1175,7 @@ fn main() {
 
                                         #[cfg(not(target_os = "macos"))]
                                         {
-                                            if let Err(e) = open::that("https://helix-db.com/dashboard") {
+                                            if let Err(_e) = open::that("https://helix-db.com/dashboard") {
                                                 println!("Failed to open url");
                                                 println!("Please visit https://helix-db.com/dashboard");
                                             }

--- a/helixdb/src/helix_engine/bm25/bm25.rs
+++ b/helixdb/src/helix_engine/bm25/bm25.rs
@@ -1,10 +1,10 @@
 use heed3::{types::*, Database, Env, RoTxn, RwTxn};
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use std::{borrow::Cow, collections::HashMap};
 
 use crate::{
     helix_engine::{
-        storage_core::{storage_core::HelixGraphStorage, storage_methods::StorageMethods},
+        storage_core::storage_core::HelixGraphStorage,
         types::GraphError,
         vector_core::{hnsw::HNSW, vector::HVector},
     },
@@ -43,8 +43,8 @@ pub trait BM25 {
     ) -> Result<Vec<(u128, f32)>, GraphError>;
     fn calculate_bm25_score(
         &self,
-        term: &str,
-        doc_id: u128,
+        _term: &str,
+        _doc_id: u128,
         tf: u32,
         doc_length: u32,
         df: u32,

--- a/helixdb/src/helix_engine/bm25/bm25_tests.rs
+++ b/helixdb/src/helix_engine/bm25/bm25_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::helix_engine::bm25::bm25::{BM25, HBM25Config, HybridSearch, BM25Metadata, PostingListEntry};
+    use crate::helix_engine::bm25::bm25::{BM25, HBM25Config, HybridSearch, BM25Metadata};
     use crate::helix_engine::{
         storage_core::storage_core::HelixGraphStorage,
         graph_core::config::Config,

--- a/helixdb/src/helix_engine/graph_core/graph_core.rs
+++ b/helixdb/src/helix_engine/graph_core/graph_core.rs
@@ -1,25 +1,7 @@
 use crate::helix_engine::storage_core::storage_core::HelixGraphStorage;
-use crate::helix_engine::storage_core::storage_methods::StorageMethods;
 use crate::helix_engine::types::GraphError;
-use crate::props;
-use crate::protocol::filterable::{Filterable, FilterableType};
-use crate::protocol::remapping::{Remapping, ResponseRemapping};
-use std::collections::HashMap;
-use std::ops::Deref;
-use std::str;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
-use super::config::VectorConfig;
-use crate::helixc::parser::helix_parser::{
-    BooleanOp, Expression, GraphStep, HelixParser, IdType, Source, StartNode, Statement, Step,
-    Traversal,
-};
-use crate::protocol::traversal_value::TraversalValue;
-use crate::protocol::{
-    items::{Edge, Node},
-    return_values::ReturnValue,
-    value::Value,
-};
 
 use crate::helix_engine::graph_core::config::Config;
 
@@ -94,7 +76,7 @@ impl HelixGraphEngine {
     //     json_string
     // }
 
-    pub fn query(&self, query: String, params: Vec<QueryInput>) -> Result<String, GraphError> {
+    pub fn query(&self, _query: String, _params: Vec<QueryInput>) -> Result<String, GraphError> {
         Ok(String::new())
     }
     //     let ast: Source = match HelixParser::parse_source(query.as_str()) {

--- a/helixdb/src/helix_engine/graph_core/ops/bm25/search_bm25.rs
+++ b/helixdb/src/helix_engine/graph_core/ops/bm25/search_bm25.rs
@@ -5,10 +5,10 @@ use crate::helix_engine::{
     bm25::bm25::BM25,
     graph_core::traversal_iter::RoTraversalIterator,
     storage_core::{storage_core::HelixGraphStorage, storage_methods::StorageMethods},
-    types::{GraphError, VectorError},
-    vector_core::{hnsw::HNSW, vector::HVector},
+    types::GraphError,
+    vector_core::hnsw::HNSW,
 };
-use std::{iter::once, sync::Arc};
+use std::sync::Arc;
 
 pub struct SearchBM25<'scope, 'inner> {
     txn: &'scope RoTxn<'scope>,

--- a/helixdb/src/helix_engine/graph_core/ops/source/add_e.rs
+++ b/helixdb/src/helix_engine/graph_core/ops/source/add_e.rs
@@ -45,8 +45,8 @@ pub trait AddEAdapter<'a, 'b>: Iterator<Item = Result<TraversalVal, GraphError>>
         properties: Option<Vec<(String, Value)>>,
         from_node: u128,
         to_node: u128,
-        should_check: bool,
-        edge_type: EdgeType,
+        _should_check: bool,
+        _edge_type: EdgeType,
     ) -> RwTraversalIterator<'a, 'b, impl Iterator<Item = Result<TraversalVal, GraphError>>>;
 
     fn node_vec_exists(&self, node_vec_id: &u128, edge_type: EdgeType) -> bool;
@@ -62,9 +62,9 @@ impl<'a, 'b, I: Iterator<Item = Result<TraversalVal, GraphError>>> AddEAdapter<'
         properties: Option<Vec<(String, Value)>>,
         from_node: u128,
         to_node: u128,
-        should_check: bool,
+        _should_check: bool,
         // edge_types: (EdgeType, EdgeType),
-        edge_type: EdgeType,
+        _edge_type: EdgeType,
     ) -> RwTraversalIterator<'a, 'b, impl Iterator<Item = Result<TraversalVal, GraphError>>> {
         let edge = Edge {
             id: v6_uuid(),

--- a/helixdb/src/helix_engine/graph_core/ops/source/bulk_add_e.rs
+++ b/helixdb/src/helix_engine/graph_core/ops/source/bulk_add_e.rs
@@ -27,7 +27,7 @@ pub trait BulkAddEAdapter<'a, 'b>: Iterator<Item = Result<TraversalVal, GraphErr
         self,
         edges: Vec<(u128, u128, u128)>,
         should_check_nodes: bool,
-        chunk_size: usize,
+        _chunk_size: usize,
     ) -> RwTraversalIterator<'a, 'b, impl Iterator<Item = Result<TraversalVal, GraphError>>>;
 }
 
@@ -100,11 +100,11 @@ impl<'a, 'b, I: Iterator<Item = Result<TraversalVal, GraphError>>> BulkAddEAdapt
         // OUT EDGES
         let mut prev_out = None;
 
-        edges.sort_unstable_by(|(from, to, id), (from_, to_, id_)| {
-            if from == from_ {
+        edges.sort_unstable_by(|(_from, _to, id), (_from_, _to_, id_)| {
+            if _from == _from_ {
                 id.cmp(id_)
             } else {
-                from.cmp(from_)
+                _from.cmp(_from_)
             }
         });
 
@@ -140,11 +140,11 @@ impl<'a, 'b, I: Iterator<Item = Result<TraversalVal, GraphError>>> BulkAddEAdapt
         println!("Adding in edges");
         // IN EDGES
         edges.sort_unstable_by(
-            |(from, to, id), (from_, to_, id_)| {
-                if to == to_ {
+            |(_from, _to, id), (_from_, _to_, id_)| {
+                if _to == _to_ {
                     id.cmp(id_)
                 } else {
-                    to.cmp(to_)
+                    _to.cmp(_to_)
                 }
             },
         );

--- a/helixdb/src/helix_engine/graph_core/ops/source/bulk_add_n.rs
+++ b/helixdb/src/helix_engine/graph_core/ops/source/bulk_add_n.rs
@@ -40,7 +40,7 @@ impl<'a, 'b, I: Iterator<Item = Result<TraversalVal, GraphError>>> BulkAddNAdapt
         let mut result: Result<TraversalVal, GraphError> = Ok(TraversalVal::Empty);
         nodes.sort_unstable_by_key(|node| *node);
         let chunks = nodes.chunks_mut(chunk_size);
-        let secondary_indices = secondary_indices.unwrap_or(&[]).to_vec();
+        let _secondary_indices = secondary_indices.unwrap_or(&[]).to_vec();
         let mut count = 0;
         for chunk in chunks {
             for node in chunk {

--- a/helixdb/src/helix_engine/graph_core/ops/tr_val.rs
+++ b/helixdb/src/helix_engine/graph_core/ops/tr_val.rs
@@ -62,7 +62,7 @@ impl Traversable for TraversalVal {
             TraversalVal::Edge(edge) => edge.id,
 
             TraversalVal::Vector(vector) => vector.id,
-            TraversalVal::Value(value) => unreachable!(),
+            TraversalVal::Value(_value) => unreachable!(),
             TraversalVal::Empty => 0,
             t => {
                 println!("invalid traversal value {:?}", t);

--- a/helixdb/src/helix_engine/graph_core/ops/vectors/insert.rs
+++ b/helixdb/src/helix_engine/graph_core/ops/vectors/insert.rs
@@ -27,7 +27,7 @@ pub trait InsertVAdapter<'a, 'b>: Iterator<Item = Result<TraversalVal, GraphErro
     fn insert_v<F>(
         self,
         vec: &Vec<f64>,
-        label: &str,
+        _label: &str,
         fields: Option<Vec<(String, Value)>>,
     ) -> RwTraversalIterator<'a, 'b, impl Iterator<Item = Result<TraversalVal, GraphError>>>
     where

--- a/helixdb/src/helix_engine/graph_core/traversal_tests.rs
+++ b/helixdb/src/helix_engine/graph_core/traversal_tests.rs
@@ -2,42 +2,37 @@ use std::{sync::Arc, time::Instant};
 
 use crate::{
     helix_engine::graph_core::ops::{
-        source::{bulk_add_e::BulkAddEAdapter, e_from_type::EFromTypeAdapter},
+        source::e_from_type::EFromTypeAdapter,
         util::drop::Drop,
     },
     props,
 };
 use crate::{
     helix_engine::graph_core::ops::{
-        source::{n_from_index::NFromIndexAdapter, n_from_type::NFromTypeAdapter},
+        source::n_from_type::NFromTypeAdapter,
         util::paths::ShortestPathAdapter,
     },
     protocol::{
         filterable::Filterable,
         id::ID,
-        items::{Edge, Node},
-        traversal_value::TraversalValue,
         value::Value,
     },
 };
-use crate::{
-    helix_engine::{
+use crate::helix_engine::{
         graph_core::ops::{
             g::G,
             in_::{in_e::InEdgesAdapter, to_n::ToNAdapter},
             out::{from_n::FromNAdapter, out::OutAdapter},
             source::{
-                add_n::AddNAdapter, bulk_add_n::BulkAddNAdapter, e_from_id::EFromIdAdapter,
+                add_n::AddNAdapter, e_from_id::EFromIdAdapter,
                 n_from_id::NFromIdAdapter,
             },
             tr_val::{Traversable, TraversalVal},
             util::{dedup::DedupAdapter, range::RangeAdapter},
         },
-        storage_core::{storage_core::HelixGraphStorage, storage_methods::StorageMethods},
+        storage_core::storage_core::HelixGraphStorage,
         types::GraphError,
-    },
-    protocol::items::v6_uuid,
-};
+    };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
@@ -169,7 +164,7 @@ fn test_out() {
         .collect_to::<Vec<_>>();
 
     txn.commit().unwrap();
-    let mut txn = storage.graph_env.write_txn().unwrap();
+    let txn = storage.graph_env.write_txn().unwrap();
 
     // let nodes = VFromId::new(&storage, &txn, person1.id.as_str())
     //     .out("knows")
@@ -1485,7 +1480,7 @@ fn huge_traversal() {
     let (storage, _temp_dir) = setup_test_db();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
-    let mut start = Instant::now();
+    let start = Instant::now();
     let mut nodes = Vec::with_capacity(1000_000);
     for i in 0..1000_000 {
         let id = G::new_mut(Arc::clone(&storage), &mut txn)

--- a/helixdb/src/helix_engine/storage_core/storage_core.rs
+++ b/helixdb/src/helix_engine/storage_core/storage_core.rs
@@ -1,6 +1,6 @@
 use crate::{
     helix_engine::{
-        bm25::bm25::{HBM25Config, BM25},
+        bm25::bm25::HBM25Config,
         graph_core::config::Config,
         storage_core::storage_methods::StorageMethods,
         types::GraphError,
@@ -14,7 +14,6 @@ use crate::{
         filterable::Filterable,
         items::{Edge, Node},
         label_hash::hash_label,
-        value::Value,
     },
 };
 

--- a/helixdb/src/helix_engine/storage_core/storage_methods.rs
+++ b/helixdb/src/helix_engine/storage_core/storage_methods.rs
@@ -1,8 +1,5 @@
 use crate::helix_engine::types::GraphError;
-use crate::protocol::{
-    items::{Edge, Node},
-    value::Value,
-};
+use crate::protocol::items::{Edge, Node};
 use heed3::{RoTxn, RwTxn};
 
 pub trait DBMethods {

--- a/helixdb/src/helix_engine/vector_core/hnsw.rs
+++ b/helixdb/src/helix_engine/vector_core/hnsw.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 
 use crate::{helix_engine::types::VectorError, protocol::value::Value};
 use crate::helix_engine::vector_core::vector::HVector;

--- a/helixdb/src/helix_engine/vector_core/vector_core.rs
+++ b/helixdb/src/helix_engine/vector_core/vector_core.rs
@@ -461,7 +461,7 @@ impl HNSW for VectorCore {
         with_data: bool,
     ) -> Result<HVector, VectorError> {
         let key = Self::vector_key(id, level);
-        let mut vector = match self.vectors_db.get(txn, key.as_ref())? {
+        let vector = match self.vectors_db.get(txn, key.as_ref())? {
             Some(bytes) => {
                 let vector = match with_data {
                     true => HVector::from_bytes(id, level, &bytes),

--- a/helixdb/src/helix_gateway/connection/connection.rs
+++ b/helixdb/src/helix_gateway/connection/connection.rs
@@ -52,7 +52,7 @@ impl<R: AsyncRuntime + Clone + Send + Sync + 'static> ConnectionHandler<R> {
 
         let active_connections = Arc::clone(&self.active_connections);
         let thread_pool_sender = self.thread_pool.sender.clone();
-        let address = self.address.clone();
+        let _address = self.address.clone();
 
 
         let runtime = self.runtime.clone();

--- a/helixdb/src/helixc/analyzer/analyzer.rs
+++ b/helixdb/src/helixc/analyzer/analyzer.rs
@@ -9,12 +9,12 @@ use crate::{
             bool_op::{BoolOp, Eq, Gt, Gte, Lt, Lte, Neq},
             generator_types::{
                 Assignment as GeneratedAssignment, BoExp, Drop as GeneratedDrop,
-                ForEach as GeneratedForEach, ForLoopInVariable, ForVariable, IdentifierType,
+                ForEach as GeneratedForEach, ForLoopInVariable, ForVariable,
                 Parameter as GeneratedParameter, Query as GeneratedQuery, ReturnValue,
                 ReturnValueExpr, Source as GeneratedSource, Statement as GeneratedStatement,
             },
             object_remapping_generation::{
-                ExcludeField, FieldRemapping, IdentifierRemapping, ObjectRemapping, Remapping,
+                ExcludeField, IdentifierRemapping, ObjectRemapping, Remapping,
                 RemappingType, TraversalRemapping, ValueRemapping,
             },
             source_steps::{
@@ -27,21 +27,18 @@ use crate::{
                 Traversal as GeneratedTraversal, TraversalType, Where, WhereExists, WhereRef,
             },
             utils::{
-                GenRef, GeneratedType, GeneratedValue, RustType as GeneratedRustType, Separator,
+                GenRef, GeneratedValue, Separator,
             },
         },
         parser::{
-            helix_parser::{ShortestPath, *},
+            helix_parser::*,
             location::Loc,
         },
     },
     protocol::{date::Date, value::Value},
 };
 
-use std::{
-    collections::{HashMap, HashSet},
-    ops::{ControlFlow, Deref},
-};
+use std::collections::{HashMap, HashSet};
 
 use super::{fix::Fix, pretty};
 
@@ -3007,7 +3004,7 @@ impl<'a> Ctx<'a> {
                                     new_value: inner_traversal,
                                 })
                             }
-                            ExpressionType::Exists(exists) => {
+                            ExpressionType::Exists(_exists) => {
                                 todo!()
                             }
                             ExpressionType::BooleanLiteral(bo_lit) => {

--- a/helixdb/src/helixc/analyzer/types.rs
+++ b/helixdb/src/helixc/analyzer/types.rs
@@ -3,15 +3,13 @@ use std::collections::HashMap;
 use crate::helixc::{
     generator::{
         generator_types::{
-            Assignment as GeneratedAssignment, EdgeSchema as GeneratedEdgeSchema,
-            NodeSchema as GeneratedNodeSchema, Parameter as GeneratedParameter, SchemaProperty,
-            Statement as GeneratedStatement, VectorSchema as GeneratedVectorSchema,
+            EdgeSchema as GeneratedEdgeSchema,
+            NodeSchema as GeneratedNodeSchema, Parameter as GeneratedParameter, SchemaProperty, VectorSchema as GeneratedVectorSchema,
         },
-        traversal_steps::Traversal as GeneratedTraversal,
         utils::{GenRef, GeneratedType, GeneratedValue, RustType as GeneratedRustType},
     },
     parser::helix_parser::{
-        Assignment, DefaultValue, EdgeSchema, FieldPrefix, FieldType, NodeSchema, Parameter,
+        DefaultValue, EdgeSchema, FieldType, NodeSchema, Parameter,
         VectorSchema,
     },
 };

--- a/helixdb/src/helixc/generator/bool_op.rs
+++ b/helixdb/src/helixc/generator/bool_op.rs
@@ -22,7 +22,7 @@ impl Display for BoolOp {
             BoolOp::Lte(lte) => format!("{}", lte),
             BoolOp::Eq(eq) => format!("{}", eq),
             BoolOp::Neq(neq) => format!("{}", neq),
-            BoolOp::Contains(cont) => unimplemented!(),
+            BoolOp::Contains(_cont) => unimplemented!(),
         };
         write!(f, "map_or(false, |v| *v{})", s)
     }

--- a/helixdb/src/helixc/generator/generator_types.rs
+++ b/helixdb/src/helixc/generator/generator_types.rs
@@ -1,16 +1,15 @@
 use core::fmt;
 use std::{
-    collections::HashMap,
     fmt::Display,
-    io::{self, Write},
+    io::Write,
 };
 
-use crate::{helixc::parser::helix_parser::FieldPrefix, protocol::value::Value};
+use crate::helixc::parser::helix_parser::FieldPrefix;
 
 use super::{
-    traversal_steps::{ShouldCollect, Traversal},
+    traversal_steps::Traversal,
     tsdisplay::ToTypeScript,
-    utils::{write_headers, write_properties, GenRef, GeneratedType, GeneratedValue},
+    utils::{write_headers, GenRef, GeneratedType, GeneratedValue},
 };
 
 pub struct Source {
@@ -367,7 +366,7 @@ pub struct ForEach {
 impl Display for ForEach {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.for_variables {
-            ForVariable::ObjectDestructure(variables) => {
+            ForVariable::ObjectDestructure(_variables) => {
                 write!(
                     f,
                     "for data in data.{}",
@@ -380,7 +379,7 @@ impl Display for ForEach {
                     self.in_variable
                 )?;
             }
-            ForVariable::Identifier(variable) => {
+            ForVariable::Identifier(_variable) => {
                 write!(f, "for data in {}", self.in_variable)?;
             }
             ForVariable::Empty => {

--- a/helixdb/src/helixc/generator/source_steps.rs
+++ b/helixdb/src/helixc/generator/source_steps.rs
@@ -165,7 +165,7 @@ impl Display for SearchBM25 {
 impl Display for SourceStep {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SourceStep::Identifier(identifier) => write!(f, ""),
+            SourceStep::Identifier(_identifier) => write!(f, ""),
             SourceStep::AddN(add_n) => write!(f, "{}", add_n),
             SourceStep::AddE(add_e) => write!(f, "{}", add_e),
             SourceStep::AddV(add_v) => write!(f, "{}", add_v),

--- a/helixdb/src/helixc/generator/traversal_steps.rs
+++ b/helixdb/src/helixc/generator/traversal_steps.rs
@@ -3,15 +3,12 @@ use crate::helixc::generator::utils::write_properties;
 use super::{
     bool_op::BoolOp,
     generator_types::BoExp,
-    object_remapping_generation::{ClosureFieldRemapping, ExcludeField, FieldRemapping, Remapping},
+    object_remapping_generation::Remapping,
     source_steps::SourceStep,
     utils::{GenRef, GeneratedValue, Order, Separator},
 };
 use core::fmt;
-use std::{
-    clone,
-    fmt::{Debug, Display},
-};
+use std::fmt::{Debug, Display};
 
 #[derive(Clone)]
 pub enum TraversalType {
@@ -213,16 +210,16 @@ impl Debug for Step {
             Step::ToN => write!(f, "ToN"),
             Step::PropertyFetch(property) => write!(f, "check_property({})", property),
 
-            Step::Out(out) => write!(f, "Out"),
-            Step::In(in_) => write!(f, "In"),
-            Step::OutE(out_e) => write!(f, "OutE"),
-            Step::InE(in_e) => write!(f, "InE"),
-            Step::Where(where_) => write!(f, "Where"),
-            Step::Range(range) => write!(f, "Range"),
-            Step::OrderBy(order_by) => write!(f, "OrderBy"),
-            Step::BoolOp(bool_op) => write!(f, "Bool"),
-            Step::Remapping(remapping) => write!(f, "Remapping"),
-            Step::ShortestPath(shortest_path) => write!(f, "ShortestPath"),
+            Step::Out(_out) => write!(f, "Out"),
+            Step::In(_in_) => write!(f, "In"),
+            Step::OutE(_out_e) => write!(f, "OutE"),
+            Step::InE(_in_e) => write!(f, "InE"),
+            Step::Where(_where_) => write!(f, "Where"),
+            Step::Range(_range) => write!(f, "Range"),
+            Step::OrderBy(_order_by) => write!(f, "OrderBy"),
+            Step::BoolOp(_bool_op) => write!(f, "Bool"),
+            Step::Remapping(_remapping) => write!(f, "Remapping"),
+            Step::ShortestPath(_shortest_path) => write!(f, "ShortestPath"),
         }
     }
 }
@@ -329,7 +326,7 @@ pub struct WhereMut {
     pub expr: BoExp,
 }
 impl Display for WhereMut {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         unimplemented!();
     }
 }

--- a/helixdb/src/helixc/generator/tsdisplay.rs
+++ b/helixdb/src/helixc/generator/tsdisplay.rs
@@ -1,4 +1,3 @@
-use std::io::{self, Write};
 
 pub trait ToTypeScript {
     fn to_typescript(&self) -> String;

--- a/helixdb/src/helixc/generator/utils.rs
+++ b/helixdb/src/helixc/generator/utils.rs
@@ -1,8 +1,7 @@
-use std::{fmt::{self, Debug, Display}, io::{self, Write}};
+use std::{fmt::{self, Debug, Display}, io::Write};
 
 use crate::helixc::parser::helix_parser::IdType;
 
-use super::tsdisplay::ToTypeScript;
 
 #[derive(Clone)]
 pub enum GenRef<T>
@@ -62,7 +61,7 @@ where
             GenRef::RefLiteral(t) => t,
             GenRef::Unknown => panic!("Cannot get inner of unknown"),
             GenRef::Std(t) => t,
-            GenRef::Id(t) => panic!("Cannot get inner of unknown"),
+            GenRef::Id(_t) => panic!("Cannot get inner of unknown"),
         }
     }
 }

--- a/helixdb/src/protocol/date.rs
+++ b/helixdb/src/protocol/date.rs
@@ -1,13 +1,13 @@
 use core::fmt;
-use std::{fmt::Display, ops::Deref};
+use std::ops::Deref;
 
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{
-    de::{DeserializeSeed, VariantAccess, Visitor},
+    de::Visitor,
     ser::Error,
-    Deserializer, Serializer,
+    Deserializer,
 };
-use sonic_rs::{Deserialize, Serialize};
+use sonic_rs::Deserialize;
 
 use super::value::Value;
 

--- a/helixdb/src/protocol/id.rs
+++ b/helixdb/src/protocol/id.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::ops::Deref;
 
 use serde::{
-    de::{DeserializeSeed, VariantAccess, Visitor},
+    de::Visitor,
     ser::Error,
     Deserializer, Serializer,
 };

--- a/helixdb/src/protocol/items.rs
+++ b/helixdb/src/protocol/items.rs
@@ -1,6 +1,5 @@
-use super::value::{properties_format, Value};
+use super::value::Value;
 use crate::helix_engine::types::GraphError;
-use bincode::Options;
 use sonic_rs::{Deserialize, Serialize};
 use std::{cmp::Ordering, collections::HashMap};
 use uuid::Uuid;

--- a/helixdb/src/protocol/label_hash.rs
+++ b/helixdb/src/protocol/label_hash.rs
@@ -1,8 +1,5 @@
 use std::hash::Hasher;
 
-use rand::Rng;
-use twox_hash::XxHash32;
-use uuid::timestamp;
 
 #[inline(always)]
 pub fn hash_label(label: &str, seed: Option<u32>) -> [u8; 4] {


### PR DESCRIPTION
## Summary
- silence some unused variable warnings using underscores
- run `cargo fix` to clean up unused imports

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_6844b07c33ec832da1484d3ee16f99fc